### PR TITLE
New genesis block for testnet

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -256,7 +256,7 @@ public:
 };
 
 /** base58-encoded Bitcoin addresses.
- * Public-key-hash-addresses have version 0 (or 111 testnet).
+ * Public-key-hash-addresses have version 23 (or 65 testnet).
  * The data vector contains RIPEMD160(SHA256(pubkey)), where pubkey is the serialized public key.
  * Script-hash-addresses have version 5 (or 196 testnet).
  * The data vector contains RIPEMD160(SHA256(cscript)), where cscript is the serialized redemption script.
@@ -280,7 +280,7 @@ public:
     {
         PUBKEY_ADDRESS = 23,
         SCRIPT_ADDRESS = 5,
-        PUBKEY_ADDRESS_TEST = 111,
+        PUBKEY_ADDRESS_TEST = 65,
         SCRIPT_ADDRESS_TEST = 196,
     };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2052,11 +2052,11 @@ bool LoadBlockIndex(bool fAllowNew)
 {
     if (fTestNet)
     {
-        pchMessageStart[0] = 0xfc;
-        pchMessageStart[1] = 0xc1;
-        pchMessageStart[2] = 0xb7;
-        pchMessageStart[3] = 0xdc;
-        hashGenesisBlock = uint256("0xc2b4cdf03c86099a0758f1c018d1a10bf05afab436c92b93b42bb88970de9821");
+        pchMessageStart[0] = 0xeb;
+        pchMessageStart[1] = 0xb0;
+        pchMessageStart[2] = 0xa6;
+        pchMessageStart[3] = 0xcb;
+        hashGenesisBlock = uint256("0xf423fe8eb935851f4baa40cfeb7120d84be32adf7876abf0fd293358a90f27a0");
     }
 
     //
@@ -2096,8 +2096,8 @@ bool LoadBlockIndex(bool fAllowNew)
 
         if (fTestNet)
         {
-            block.nTime    = 1390598805;             
-            block.nNonce   = 94361;
+            block.nTime    = 1396273344;
+            block.nNonce   = 2543986232;
         }
 
         //// debug print


### PR DESCRIPTION
Current testnet in Auracoin does not work as it does not have a valid genesis block. This commit adds a genesis block, changes the pchStartMessage for the testnet and uses the letter T for testnet addresses.
